### PR TITLE
Add refs to Component class

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,10 +9,12 @@ declare namespace React {
   type Props = {[key: string]: any};
   type State = Props;
   type Context = Props;
+  type Refs = Props;
 
   export class Component {
     context: Context;
     props: Props;
+    refs: Refs;
     state: State;
     setState: (partialState: State, cb?: Function) => void;
     constructor(props: Props, context?: Context);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@types/react",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "",
   "main": "index.d.ts",
   "scripts": {


### PR DESCRIPTION
To utilize some `this.refs` on components, this PR adds `refs` to the `Component` class.