### PR TITLE
add support for react 16 fragments

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,6 +27,7 @@ declare namespace React {
   function cloneElement(element: any, props?: Props, ...children: any[]): any
 
   var Children: ReactChildren;
+  const Fragment: any;
   var PropTypes: ReactPropTypes;
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@types/react",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "",
   "main": "index.d.ts",
   "scripts": {


### PR DESCRIPTION
One of the new features in React 16 is called Fragments:
https://reactjs.org/blog/2017/09/26/react-v16.0.html#new-render-return-types-fragments-and-strings
https://reactjs.org/docs/fragments.html

This is the minimal change we need to make in order to support fragments in typescript.

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f2982c175477516d52bdc40191d7829d0531ba35/types/react/index.d.ts#L269

<img width="1052" alt="screen shot 2018-03-23 at 11 12 14 am" src="https://user-images.githubusercontent.com/32328921/37847006-a3ba0e08-2e8c-11e8-8e23-d0b1c0f16569.png">

<img width="554" alt="screen shot 2018-03-23 at 11 24 37 am" src="https://user-images.githubusercontent.com/32328921/37847083-d4695540-2e8c-11e8-86bb-79f6e26d6efa.png">


Relevant to the quest for React 16: 
https://github.com/Clever/components/pull/274
https://github.com/Clever/components/pull/275

