### PR TITLE
remove extraneous import

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,8 +2,6 @@
 // Type definitions for React v0.14
 // Project: http://facebook.github.io/react/
 
-import * as PropTypes from "prop-types";
-
 export = React;
 export as namespace React;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@types/react",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "",
   "main": "index.d.ts",
   "scripts": {


### PR DESCRIPTION
Introduced here https://github.com/Clever/minimal-react-typings/pull/8 by mistake
This dependency isn't used and it's also not in the package.json